### PR TITLE
feat: add JSONBody parameter provider and assert utility function

### DIFF
--- a/.antelope/output/api/beta/index.d.ts
+++ b/.antelope/output/api/beta/index.d.ts
@@ -526,7 +526,7 @@ export declare const WebsocketHandler: (location?: string | undefined) => import
  * @param context Request context
  * @returns Body buffer
  */
-export declare function ReadBody(context: RequestContext): unknown;
+export declare function ReadBody(context: RequestContext): Promise<Buffer>;
 /**
  * Set the ParameterProvider on a Handler or Property.
  *
@@ -589,6 +589,24 @@ export declare function AddParameterModifier(target: any, key: PropertyKey, inde
  * ```
  */
 export declare const RawBody: () => import("@ajs/core/beta/decorators").PropertyDecorator & import("@ajs/core/beta/decorators").ParameterDecorator;
+/**
+ * Parameter Provider: JSON Request Body.
+ *
+ * Parses the HTTP request body as JSON and provides the resulting object.
+ * This is useful for handling JSON payloads in POST, PUT, and other methods
+ * that accept request bodies.
+ *
+ * Example:
+ * ```ts
+ * @Post()
+ * async createUser(@JSONBody body: { name: string; email: string }) {
+ *   // body is already parsed as a JavaScript object
+ *   const user = await saveUser(body);
+ *   return new HTTPResult(201, user);
+ * }
+ * ```
+ */
+export declare const JSONBody: () => import("@ajs/core/beta/decorators").PropertyDecorator & import("@ajs/core/beta/decorators").ParameterDecorator;
 /**
  * Parameter Provider: Request Parameter.
  *
@@ -756,3 +774,26 @@ export declare const Connection: () => import("@ajs/core/beta/decorators").Prope
  * ```
  */
 export declare const MultiParameter: (name: string, source?: "query" | "header" | undefined) => import("@ajs/core/beta/decorators").PropertyDecorator & import("@ajs/core/beta/decorators").ParameterDecorator;
+/**
+ * Assert a condition is truthy, throwing an HTTPResult error if false.
+ *
+ * This utility function can be used in API handlers to validate conditions
+ * and return appropriate HTTP error responses when validations fail.
+ *
+ * @param condition The condition to assert (truthy values pass, falsy values throw)
+ * @param code HTTP status code to use for the error response (e.g., 400, 404, 500)
+ * @param message Error message to include in the response body
+ * @throws {HTTPResult} Throws an HTTPResult with the specified code and message if condition is falsy
+ *
+ * Example:
+ * ```ts
+ * @Get('users/:id')
+ * async getUser(@Parameter('id') id: string) {
+ *   const user = await findUser(id);
+ *   assert(user, 404, "User not found");
+ *
+ *   return new HTTPResult(200, user);
+ * }
+ * ```
+ */
+export declare function assert<T>(condition: T, code: number, message: string): asserts condition;

--- a/playground/src/index.ts
+++ b/playground/src/index.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Post, Put, Delete } from '@ajs/api/beta';
+import { Controller, Get, Post, Put, Delete, JSONBody, Parameter, assert } from '@ajs/api/beta';
 
 export class PlaygroundController extends Controller('/playground') {
   @Get('/hello')
@@ -13,7 +13,7 @@ export class PlaygroundController extends Controller('/playground') {
   }
 
   @Put('/update')
-  async update(body: any) {
+  async update(@JSONBody() body: unknown) {
     console.log('update', body);
     return { updated: body };
   }
@@ -22,6 +22,13 @@ export class PlaygroundController extends Controller('/playground') {
   async remove() {
     console.log('remove');
     return { message: 'Deleted' };
+  }
+
+  @Get('/ping')
+  async ping(@Parameter('pong', 'query') pong: string) {
+    assert(pong === 'pong', 400, 'Pong must be pong');
+
+    return { message: 'Pong', pong };
   }
 }
 


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/AntelopeJS/interface-api/pull/1

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

- Adding new `assert` function to validates conditions and automatically returns appropriate HTTP errors when validations fail
- Adding new `JSONBody` parameters to automatically transform the body of a HTTP request in a JSON Format.
- Fixing the return type of the Readbody by adding the promise return type

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
