### PR TITLE
feat(cors): make credentials, max-age and allowed headers configurable

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     }
   },
   "dependencies": {
-    "@antelopejs/interface-api": "^0.0.2",
+    "@antelopejs/interface-api": "^0.0.4",
     "@antelopejs/interface-api-util": "^0.0.2",
     "@antelopejs/interface-core": "^0.0.5",
     "reflect-metadata": "^0.2.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@antelopejs/interface-api':
-        specifier: ^0.0.2
-        version: 0.0.2
+        specifier: ^0.0.4
+        version: 0.0.4
       '@antelopejs/interface-api-util':
         specifier: ^0.0.2
         version: 0.0.2
@@ -85,8 +85,14 @@ packages:
   '@antelopejs/interface-api@0.0.2':
     resolution: {integrity: sha512-wD9kODuc5cns8mCVv4hLL3N8eF2iXtXoMgtDS7zJ3hZZoPnlpxZ7mDP4fMRUDBl0pm9ZTPKb5abzu3BZg6T/EA==}
 
+  '@antelopejs/interface-api@0.0.4':
+    resolution: {integrity: sha512-vrDLOQPt3LMHc8UUVzUVIuI3tJvkX8iFqdDsuUpW6vxlW4KwMS46k5O6/TlnqHjb9U9A1lSRkCLFhf98oCEMDQ==}
+
   '@antelopejs/interface-core@0.0.2':
     resolution: {integrity: sha512-CmtOJvSCRj20GOQhrE0PpHybGaW1G1lrepiKHVJa/bclhrvFYgHV0MH84TMpMOHESQT/+wuup007tfXAwaI+Eg==}
+
+  '@antelopejs/interface-core@0.0.3':
+    resolution: {integrity: sha512-Kw3ffGiQHKJ88AqdFfPuwzl+v0w6QqzqiqnLY7M0MYYw+YwdRNXh5WAJkep0ePudR9leLGXPU//FYizNaDG6yw==}
 
   '@antelopejs/interface-core@0.0.5':
     resolution: {integrity: sha512-4H6hpFfiK2+DE8vL2mEtPbq1WNch9lt40QNr9KjBrOAtnuq/zMfIlzhbEsda39m+FVkMWXfUYoVolRogVKCLIQ==}
@@ -1233,7 +1239,15 @@ snapshots:
     dependencies:
       '@antelopejs/interface-core': 0.0.2
 
+  '@antelopejs/interface-api@0.0.4':
+    dependencies:
+      '@antelopejs/interface-core': 0.0.3
+
   '@antelopejs/interface-core@0.0.2':
+    dependencies:
+      reflect-metadata: 0.2.2
+
+  '@antelopejs/interface-core@0.0.3':
     dependencies:
       reflect-metadata: 0.2.2
 

--- a/src/implementations/api/index.ts
+++ b/src/implementations/api/index.ts
@@ -1,12 +1,13 @@
 import {
   type ComputedParameter,
   ControllerMeta,
+  type CorsConfig,
   computeParameter,
   type RouteHandler,
 } from "@antelopejs/interface-api";
 import { GetMetadata } from "@antelopejs/interface-core";
 import type { Class } from "@antelopejs/interface-core/decorators";
-import { listenServers } from "../../index";
+import { getConfig, listenServers, setCorsConfig } from "../../index";
 import {
   type RequestContext,
   registerHandler,
@@ -90,6 +91,14 @@ export async function GetControllerInstance(
 
 export async function Listen(): Promise<void> {
   await listenServers();
+}
+
+export function GetCorsConfig(): CorsConfig {
+  return getConfig().cors ?? {};
+}
+
+export function SetCorsConfig(config: CorsConfig): void {
+  setCorsConfig(config);
 }
 
 interface RouteInfo {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import type * as net from "node:net";
+import type { CorsConfig } from "@antelopejs/interface-api";
 import { ImplementInterface } from "@antelopejs/interface-core";
 import { Logging } from "@antelopejs/interface-core/logging";
 import type { DevServerEndpoint } from "@antelopejs/interface-core/runtime";
@@ -28,6 +29,10 @@ export function configure(config: Config): void {
     ...config,
     servers: resolveServers(config),
   };
+}
+
+export function setCorsConfig(cors: CorsConfig): void {
+  conf = { ...conf, cors };
 }
 
 export async function construct(config: Config): Promise<void> {

--- a/src/middlewares/cors.ts
+++ b/src/middlewares/cors.ts
@@ -62,12 +62,17 @@ function addCredentialsHeader(response: HTTPResult, cors: CorsConfig): void {
   }
 }
 
+function hasStaticAllowedHeaders(cors: CorsConfig): boolean {
+  return Boolean(cors.allowedHeaders && cors.allowedHeaders.length > 0);
+}
+
 function resolveAllowedHeaders(
   cors: CorsConfig,
   requestContext: RequestContext,
 ): string {
-  if (cors.allowedHeaders && cors.allowedHeaders.length > 0) {
-    return cors.allowedHeaders.join(",");
+  const { allowedHeaders } = cors;
+  if (allowedHeaders && allowedHeaders.length > 0) {
+    return allowedHeaders.join(",");
   }
 
   return toHeaderValue(
@@ -92,7 +97,9 @@ function addPreflightHeaders(
     "Access-Control-Allow-Headers",
     resolveAllowedHeaders(cors, requestContext),
   );
-  response.addHeader("Vary", "Access-Control-Request-Headers");
+  if (!hasStaticAllowedHeaders(cors)) {
+    response.addHeader("Vary", "Access-Control-Request-Headers");
+  }
 
   if (cors.maxAge !== undefined) {
     response.addHeader("Access-Control-Max-Age", String(cors.maxAge));

--- a/src/middlewares/cors.ts
+++ b/src/middlewares/cors.ts
@@ -1,6 +1,8 @@
 import {
+  type AllowedOrigin,
   Context,
   Controller,
+  type CorsConfig,
   HandlerPriority,
   HTTPResult,
   Prefix,
@@ -8,14 +10,13 @@ import {
 } from "@antelopejs/interface-api";
 import { getConfig } from "..";
 
-type AllowedOrigin = string | RegExp | Array<string | RegExp>;
-
 type RequestHeaderValue = string | string[] | undefined;
 
 const DEFAULT_ALLOWED_METHODS = "GET,HEAD,PUT,PATCH,POST,DELETE";
 const FALSE_ORIGIN = "false";
-const TRUE_CREDENTIALS = "true";
+const CREDENTIALS_ENABLED_VALUE = "true";
 const NO_BODY_LENGTH = "0";
+const DEFAULT_CREDENTIALS = true;
 
 function isString(value: unknown): value is string {
   return typeof value === "string" || value instanceof String;
@@ -48,65 +49,94 @@ function isOriginAllowed(
   return Boolean(allowedOrigin);
 }
 
+function isCredentialsEnabled(cors: CorsConfig): boolean {
+  return cors.credentials ?? DEFAULT_CREDENTIALS;
+}
+
+function addCredentialsHeader(response: HTTPResult, cors: CorsConfig): void {
+  if (isCredentialsEnabled(cors)) {
+    response.addHeader(
+      "Access-Control-Allow-Credentials",
+      CREDENTIALS_ENABLED_VALUE,
+    );
+  }
+}
+
+function resolveAllowedHeaders(
+  cors: CorsConfig,
+  requestContext: RequestContext,
+): string {
+  if (cors.allowedHeaders && cors.allowedHeaders.length > 0) {
+    return cors.allowedHeaders.join(",");
+  }
+
+  return toHeaderValue(
+    requestContext.rawRequest.headers["access-control-request-headers"],
+  );
+}
+
 function addPreflightHeaders(
   response: HTTPResult,
   requestContext: RequestContext,
   allowedOriginHeader: string,
+  cors: CorsConfig,
 ): void {
-  const config = getConfig();
   const allowedMethods =
-    config.cors?.allowedMethods?.join(",") ?? DEFAULT_ALLOWED_METHODS;
-  const requestedHeaders = toHeaderValue(
-    requestContext.rawRequest.headers["access-control-request-headers"],
-  );
+    cors.allowedMethods?.join(",") ?? DEFAULT_ALLOWED_METHODS;
 
   response.addHeader("Access-Control-Allow-Origin", allowedOriginHeader);
   response.addHeader("Vary", "Origin");
   response.addHeader("Access-Control-Allow-Methods", allowedMethods);
-  response.addHeader("Access-Control-Allow-Credentials", TRUE_CREDENTIALS);
-  response.addHeader("Access-Control-Allow-Headers", requestedHeaders);
+  addCredentialsHeader(response, cors);
+  response.addHeader(
+    "Access-Control-Allow-Headers",
+    resolveAllowedHeaders(cors, requestContext),
+  );
   response.addHeader("Vary", "Access-Control-Request-Headers");
+
+  if (cors.maxAge !== undefined) {
+    response.addHeader("Access-Control-Max-Age", String(cors.maxAge));
+  }
+
   response.addHeader("Content-Length", NO_BODY_LENGTH);
 }
 
 function addStandardCorsHeaders(
   requestContext: RequestContext,
   allowedOriginHeader: string,
+  cors: CorsConfig,
 ): void {
   requestContext.response.addHeader(
     "Access-Control-Allow-Origin",
     allowedOriginHeader,
   );
   requestContext.response.addHeader("Vary", "Origin");
-  requestContext.response.addHeader(
-    "Access-Control-Allow-Credentials",
-    TRUE_CREDENTIALS,
-  );
+  addCredentialsHeader(requestContext.response, cors);
 }
 
 export class Cors extends Controller("") {
   @Prefix("any", "/", HandlerPriority.HIGHEST)
   cors(@Context() requestContext: RequestContext): HTTPResult | undefined {
-    const config = getConfig();
+    const cors = getConfig().cors;
 
-    if (!config.cors) {
+    if (!cors) {
       return undefined;
     }
 
     const requestOrigin = requestContext.rawRequest.headers.origin;
     const isAllowed = requestOrigin
-      ? isOriginAllowed(requestOrigin, config.cors.allowedOrigins)
+      ? isOriginAllowed(requestOrigin, cors.allowedOrigins)
       : false;
     const allowedOriginHeader =
       isAllowed && requestOrigin ? requestOrigin : FALSE_ORIGIN;
 
     if (requestContext.rawRequest.method === "OPTIONS") {
       const response = new HTTPResult(204, null);
-      addPreflightHeaders(response, requestContext, allowedOriginHeader);
+      addPreflightHeaders(response, requestContext, allowedOriginHeader, cors);
       return response;
     }
 
-    addStandardCorsHeaders(requestContext, allowedOriginHeader);
+    addStandardCorsHeaders(requestContext, allowedOriginHeader, cors);
     return undefined;
   }
 }

--- a/src/server-config.ts
+++ b/src/server-config.ts
@@ -1,5 +1,6 @@
 import type * as http from "node:http";
 import type * as https from "node:https";
+import type { CorsConfig } from "@antelopejs/interface-api";
 
 export type ServerProtocol = "http" | "https";
 export type SocketProtocol = "ws" | "wss";
@@ -18,13 +19,6 @@ export interface HTTPSConfig extends https.ServerOptions, ServerNetworkConfig {
 }
 
 export type ServerConfig = HTTPConfig | HTTPSConfig;
-
-type AllowedOrigin = string | RegExp | Array<string | RegExp>;
-
-interface CorsConfig {
-  allowedOrigins?: AllowedOrigin;
-  allowedMethods?: string[];
-}
 
 export interface Config {
   servers?: ServerConfig[];

--- a/src/test/cors.test.ts
+++ b/src/test/cors.test.ts
@@ -1,0 +1,158 @@
+import assert from "node:assert";
+import { HTTPResult, type RequestContext } from "@antelopejs/interface-api";
+import { GetCorsConfig, SetCorsConfig } from "../implementations/api";
+import { configure, getConfig, setCorsConfig } from "../index";
+import { Cors } from "../middlewares/cors";
+
+const ALLOWED_ORIGIN = "https://example.com";
+const DISALLOWED_ORIGIN = "https://evil.com";
+const REQUESTED_HEADERS = "x-custom";
+const PREFLIGHT_STATUS = 204;
+
+interface RequestHeaders {
+  origin?: string;
+  "access-control-request-headers"?: string;
+}
+
+const corsController = new Cors();
+
+function buildContext(method: string, headers: RequestHeaders): RequestContext {
+  return {
+    rawRequest: { method, headers },
+    response: new HTTPResult(),
+  } as unknown as RequestContext;
+}
+
+function preflightHeaders(headers: RequestHeaders): Record<string, string> {
+  const result = corsController.cors(buildContext("OPTIONS", headers));
+  assert.ok(result instanceof HTTPResult);
+  return result.getHeaders();
+}
+
+describe("CORS", () => {
+  let originalConfig: ReturnType<typeof getConfig>;
+
+  before(() => {
+    originalConfig = getConfig();
+  });
+
+  after(() => {
+    configure(originalConfig);
+  });
+
+  it("round-trips the configuration through the contract functions", () => {
+    SetCorsConfig({ allowedOrigins: ALLOWED_ORIGIN, credentials: false });
+
+    assert.deepEqual(GetCorsConfig(), {
+      allowedOrigins: ALLOWED_ORIGIN,
+      credentials: false,
+    });
+    assert.deepEqual(getConfig().cors, {
+      allowedOrigins: ALLOWED_ORIGIN,
+      credentials: false,
+    });
+  });
+
+  it("returns an empty configuration when CORS is unset", () => {
+    configure({ servers: [] });
+
+    assert.deepEqual(GetCorsConfig(), {});
+  });
+
+  it("skips handling when no configuration is set", () => {
+    configure({ servers: [] });
+
+    const context = buildContext("GET", { origin: ALLOWED_ORIGIN });
+    const result = corsController.cors(context);
+
+    assert.equal(result, undefined);
+    assert.deepEqual(context.response.getHeaders(), {});
+  });
+
+  it("adds standard headers for an allowed origin", () => {
+    setCorsConfig({ allowedOrigins: ALLOWED_ORIGIN });
+
+    const context = buildContext("GET", { origin: ALLOWED_ORIGIN });
+    const result = corsController.cors(context);
+    const headers = context.response.getHeaders();
+
+    assert.equal(result, undefined);
+    assert.equal(headers["Access-Control-Allow-Origin"], ALLOWED_ORIGIN);
+    assert.equal(headers["Access-Control-Allow-Credentials"], "true");
+  });
+
+  it("reports a disallowed origin as false", () => {
+    setCorsConfig({ allowedOrigins: ALLOWED_ORIGIN });
+
+    const context = buildContext("GET", { origin: DISALLOWED_ORIGIN });
+    corsController.cors(context);
+
+    assert.equal(
+      context.response.getHeaders()["Access-Control-Allow-Origin"],
+      "false",
+    );
+  });
+
+  it("omits the credentials header when credentials are disabled", () => {
+    setCorsConfig({ allowedOrigins: ALLOWED_ORIGIN, credentials: false });
+
+    const context = buildContext("GET", { origin: ALLOWED_ORIGIN });
+    corsController.cors(context);
+
+    assert.equal(
+      context.response.getHeaders()["Access-Control-Allow-Credentials"],
+      undefined,
+    );
+  });
+
+  it("emits preflight headers with configured methods and max-age", () => {
+    setCorsConfig({
+      allowedOrigins: ALLOWED_ORIGIN,
+      allowedMethods: ["GET", "POST"],
+      maxAge: 600,
+    });
+
+    const result = corsController.cors(
+      buildContext("OPTIONS", { origin: ALLOWED_ORIGIN }),
+    );
+
+    assert.ok(result instanceof HTTPResult);
+    assert.equal(result.getStatus(), PREFLIGHT_STATUS);
+    const headers = result.getHeaders();
+    assert.equal(headers["Access-Control-Allow-Methods"], "GET,POST");
+    assert.equal(headers["Access-Control-Max-Age"], "600");
+  });
+
+  it("reflects the requested headers when none are configured", () => {
+    setCorsConfig({ allowedOrigins: ALLOWED_ORIGIN });
+
+    const headers = preflightHeaders({
+      origin: ALLOWED_ORIGIN,
+      "access-control-request-headers": REQUESTED_HEADERS,
+    });
+
+    assert.equal(headers["Access-Control-Allow-Headers"], REQUESTED_HEADERS);
+  });
+
+  it("uses the configured allowed headers over the requested ones", () => {
+    setCorsConfig({
+      allowedOrigins: ALLOWED_ORIGIN,
+      allowedHeaders: ["X-A", "X-B"],
+    });
+
+    const headers = preflightHeaders({
+      origin: ALLOWED_ORIGIN,
+      "access-control-request-headers": REQUESTED_HEADERS,
+    });
+
+    assert.equal(headers["Access-Control-Allow-Headers"], "X-A,X-B");
+  });
+
+  it("omits the max-age header when it is not configured", () => {
+    setCorsConfig({ allowedOrigins: ALLOWED_ORIGIN });
+
+    const headers = preflightHeaders({ origin: ALLOWED_ORIGIN });
+
+    assert.equal(headers["Access-Control-Max-Age"], undefined);
+  });
+});

--- a/src/test/cors.test.ts
+++ b/src/test/cors.test.ts
@@ -132,6 +132,7 @@ describe("CORS", () => {
     });
 
     assert.equal(headers["Access-Control-Allow-Headers"], REQUESTED_HEADERS);
+    assert.equal(headers.Vary, "Access-Control-Request-Headers");
   });
 
   it("uses the configured allowed headers over the requested ones", () => {
@@ -146,6 +147,7 @@ describe("CORS", () => {
     });
 
     assert.equal(headers["Access-Control-Allow-Headers"], "X-A,X-B");
+    assert.equal(headers.Vary, "Origin");
   });
 
   it("omits the max-age header when it is not configured", () => {


### PR DESCRIPTION
## Summary

Extends CORS support so credentials, preflight max-age and allowed headers are configurable, and wires up the new `GetCorsConfig`/`SetCorsConfig` contract from `@antelopejs/interface-api`.

- **Contract source of truth**: `CorsConfig`/`AllowedOrigin` are now imported from `@antelopejs/interface-api` (bumped to `^0.0.4`) instead of being duplicated in `server-config.ts` and `middlewares/cors.ts`.
- **Live config**: `setCorsConfig(cors)` on the module config plus `GetCorsConfig()`/`SetCorsConfig()` implementations. The middleware re-reads `getConfig().cors` per request, so changes apply without restarting the servers.
- **New CORS fields** in `middlewares/cors.ts`:
  - `credentials` — defaults to `true` (backwards compatible); the `Access-Control-Allow-Credentials` header is omitted when set to `false`.
  - `maxAge` — emits `Access-Control-Max-Age` on the preflight (OPTIONS) response when defined.
  - `allowedHeaders` — used for `Access-Control-Allow-Headers` when provided, otherwise the requested headers are reflected (previous behaviour).

## Test plan

- `pnpm run build` ✅
- `pnpm run lint` ✅
- `pnpm run test` ✅ — 84 passing, including the new `src/test/cors.test.ts` (10 tests) covering the contract round-trip and middleware behaviour (allowed/disallowed origin, credentials toggle, preflight methods/max-age, configured vs reflected allowed headers).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extends the CORS middleware with three new configurable fields (`credentials`, `maxAge`, `allowedHeaders`) and wires up `GetCorsConfig`/`SetCorsConfig` contract implementations, consolidating the previously duplicated `CorsConfig`/`AllowedOrigin` types behind the canonical `@antelopejs/interface-api` import (bumped to `^0.0.4`).

- **New CORS options**: `credentials` defaults to `true` (backwards compatible); `maxAge` emits `Access-Control-Max-Age` on preflight; `allowedHeaders` uses a static list when provided, otherwise reflects `Access-Control-Request-Headers` — with `Vary` correctly omitted when headers are static.
- **Live config contract**: `SetCorsConfig` replaces the full `cors` slice of the module config; `GetCorsConfig` returns the current value or `{}` when unset; the middleware re-reads config per request so changes apply immediately.
- **Test coverage**: 10 new tests in `src/test/cors.test.ts` exercise every new code path including the contract round-trip, credentials toggle, preflight method/max-age headers, and static vs reflected allowed headers.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all new fields are additive and backwards compatible, the middleware re-reads config per request with no shared mutable state, and 10 new tests cover every changed code path.

The changes are purely additive: credentials defaults to true preserving old behaviour, the Vary header is correctly conditioned on whether headers are static or reflected, and both GetCorsConfig/SetCorsConfig are thin wrappers with no surprising side effects. No pre-existing logic was altered in a way that could regress.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/middlewares/cors.ts | Refactored to accept CorsConfig from the interface package; adds credentials toggle, maxAge header, and configurable allowedHeaders with correct Vary header logic |
| src/implementations/api/index.ts | Adds GetCorsConfig/SetCorsConfig contract implementations; GetCorsConfig returns {} when cors is unset, consistent with the test expectations |
| src/index.ts | Adds setCorsConfig helper that replaces the cors slice of conf via spread; straightforward and correct |
| src/server-config.ts | Removes the now-redundant local CorsConfig/AllowedOrigin types, replacing them with the canonical import from @antelopejs/interface-api |
| src/test/cors.test.ts | New test file with 10 tests covering contract round-trip, credentials toggle, preflight headers, maxAge, and static vs reflected allowed headers |
| package.json | Bumps @antelopejs/interface-api to ^0.0.4 to pick up the new CorsConfig fields (credentials, maxAge, allowedHeaders) |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant CorsMiddleware
    participant getConfig
    participant HTTPResult

    Client->>CorsMiddleware: OPTIONS /path (preflight)
    CorsMiddleware->>getConfig: getConfig().cors
    getConfig-->>CorsMiddleware: "CorsConfig { allowedOrigins, credentials, maxAge, allowedHeaders }"
    CorsMiddleware->>CorsMiddleware: isOriginAllowed(origin, cors.allowedOrigins)
    CorsMiddleware->>HTTPResult: new HTTPResult(204, null)
    CorsMiddleware->>HTTPResult: addHeader(Access-Control-Allow-Origin)
    CorsMiddleware->>HTTPResult: addHeader(Vary, Origin)
    CorsMiddleware->>HTTPResult: addHeader(Access-Control-Allow-Methods)
    alt "credentials !== false"
        CorsMiddleware->>HTTPResult: addHeader(Access-Control-Allow-Credentials, true)
    end
    alt static allowedHeaders configured
        CorsMiddleware->>HTTPResult: addHeader(Access-Control-Allow-Headers, joined list)
    else reflect request headers
        CorsMiddleware->>HTTPResult: addHeader(Access-Control-Allow-Headers, reflected)
        CorsMiddleware->>HTTPResult: addHeader(Vary, Access-Control-Request-Headers)
    end
    alt maxAge defined
        CorsMiddleware->>HTTPResult: addHeader(Access-Control-Max-Age, String(maxAge))
    end
    CorsMiddleware-->>Client: 204 preflight response

    Client->>CorsMiddleware: GET /path (standard request)
    CorsMiddleware->>getConfig: getConfig().cors
    CorsMiddleware->>CorsMiddleware: isOriginAllowed(origin, cors.allowedOrigins)
    alt "credentials !== false"
        CorsMiddleware->>HTTPResult: addHeader(Access-Control-Allow-Credentials, true)
    end
    CorsMiddleware-->>Client: passes through (undefined)
```

<sub>Reviews (3): Last reviewed commit: ["address greptile review feedback (greplo..."](https://github.com/antelopejs/api/commit/ac73fb5d0cca786272a7f87c1d9c87c55addfd33) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37502516)</sub>

<!-- /greptile_comment -->