### PR TITLE
fix(server): coerce configured port to a number before fallback

### DIFF
--- a/src/port-binding.ts
+++ b/src/port-binding.ts
@@ -83,9 +83,9 @@ function buildCandidatePorts(
 async function listenServerWithFallback(
   server: net.Server,
   config: ServerConfig,
+  requestedPort: number,
   allowPortFallback: boolean,
 ): Promise<number> {
-  const requestedPort = resolveRequestedPort(config);
   const candidatePorts = buildCandidatePorts(requestedPort, allowPortFallback);
   let portInUseError: unknown = new Error(
     `Unable to bind ${config.protocol} server on port ${requestedPort}`,
@@ -135,6 +135,7 @@ export async function listenServer(
   const boundPort = await listenServerWithFallback(
     server,
     config,
+    requestedPort,
     allowPortFallback,
   );
   config.port = boundPort;

--- a/src/port-binding.ts
+++ b/src/port-binding.ts
@@ -52,6 +52,19 @@ export function resolveBoundPort(
   return fallbackPort;
 }
 
+const MAX_PORT = 65535;
+
+function resolveRequestedPort(config: ServerConfig): number {
+  const rawPort = config.port ?? DEFAULT_HTTP_PORT;
+  const port = Number(rawPort);
+  if (!Number.isInteger(port) || port < RANDOM_PORT || port > MAX_PORT) {
+    throw new Error(
+      `Invalid ${config.protocol} server port: ${JSON.stringify(rawPort)}`,
+    );
+  }
+  return port;
+}
+
 function buildCandidatePorts(
   requestedPort: number,
   allowPortFallback: boolean,
@@ -72,7 +85,7 @@ async function listenServerWithFallback(
   config: ServerConfig,
   allowPortFallback: boolean,
 ): Promise<number> {
-  const requestedPort = config.port ?? DEFAULT_HTTP_PORT;
+  const requestedPort = resolveRequestedPort(config);
   const candidatePorts = buildCandidatePorts(requestedPort, allowPortFallback);
   let portInUseError: unknown = new Error(
     `Unable to bind ${config.protocol} server on port ${requestedPort}`,
@@ -118,7 +131,7 @@ export async function listenServer(
     return;
   }
 
-  const requestedPort = config.port ?? DEFAULT_HTTP_PORT;
+  const requestedPort = resolveRequestedPort(config);
   const boundPort = await listenServerWithFallback(
     server,
     config,

--- a/src/test/listen.test.ts
+++ b/src/test/listen.test.ts
@@ -21,6 +21,7 @@ const EXHAUSTED_BASE_PORT = 25100;
 const EXHAUSTED_RANGE_SIZE = 21;
 const MULTI_OCCUPIED_PORT = 25140;
 const MULTI_FREE_PORT = 25150;
+const STRING_PORT = 25160;
 const RANDOM_PORT = 0;
 
 interface PortInUseError {
@@ -231,6 +232,36 @@ describe("Port fallback", () => {
     assert.equal(getConfig().servers?.[1].port, MULTI_FREE_PORT);
     sinon.assert.calledOnce(registerStub);
     assert.deepEqual(registerStub.firstCall.args, ["api", endpoints]);
+  });
+
+  it("binds the numeric port when the configured port is a string", async () => {
+    stubRuntime(true);
+
+    configure({
+      autoListen: false,
+      servers: [
+        { protocol: "http", host: TEST_HOST, port: String(STRING_PORT) },
+      ],
+    } as unknown as Parameters<typeof configure>[0]);
+    start();
+    await listenServers();
+
+    const endpoints = getListeningEndpoints();
+    assert.equal(endpoints.length, 1);
+    assert.equal(endpoints[0].port, STRING_PORT);
+    assert.equal(getConfig().servers?.[0].port, STRING_PORT);
+  });
+
+  it("rejects when the configured port is not a valid number", async () => {
+    stubRuntime(true);
+
+    configure({
+      autoListen: false,
+      servers: [{ protocol: "http", host: TEST_HOST, port: "not-a-port" }],
+    } as unknown as Parameters<typeof configure>[0]);
+    start();
+
+    await assert.rejects(listenServers(), /Invalid http server port/);
   });
 
   it("clears endpoints after stop", async () => {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

N/A

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

When a server port is configured as a **string** (e.g. `port: "5010"`, as produced by some `antelope.config.ts` setups), `buildCandidatePorts` did `requestedPort + offset`, which **concatenates** instead of adding: `"5010" + 0` → `"50100"`, `"5010" + 1` → `"50101"`, …

Consequences:
- The requested port (5010) was **never actually tried** — the server bound `50100` directly.
- The startup log showed a misleading `Port 5010 in use, listening on http://localhost:50100 instead`, even though 5010 was perfectly free.

Fix:
- Add `resolveRequestedPort(config)` that coerces the configured port to a number and validates it (integer within `0–65535`), throwing a clear `Invalid <protocol> server port: …` otherwise.
- Use it both for building the candidate port list and for the "server started" log comparison, so string ports now add correctly (`5011`, `5012`, …) and invalid ports fail loudly instead of silently binding an ephemeral port.

### 📝 Test plan

Added two regression tests in `src/test/listen.test.ts`:
- `binds the numeric port when the configured port is a string` — a `"25160"` config binds `25160`, not a concatenated value.
- `rejects when the configured port is not a valid number` — `"not-a-port"` rejects with `Invalid http server port`.

Run: `pnpm test` → **86 passing**, lint and build clean.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a string-concatenation bug in `buildCandidatePorts`: when `config.port` arrived as a string (e.g. from a config file), `port + offset` produced `"50100"` instead of `5010`. The fix introduces `resolveRequestedPort`, which coerces the raw port value to a number and validates it before any arithmetic is performed.

- Adds `resolveRequestedPort(config)` that converts `config.port` to a number via `Number()`, rejects non-integers and out-of-range values with a clear error, and is called once in `listenServer` with the result forwarded to `listenServerWithFallback` — incidentally also resolving the previously noted redundant double-call.
- Adds two regression tests covering the string-port fix and invalid-port rejection.

<h3>Confidence Score: 5/5</h3>

The change is narrowly scoped to port coercion and validation; it cannot regress the happy path and hardens the error path with a clear exception.

The logic change is small and correct: `Number()` coercion followed by integer range validation cleanly replaces the raw string arithmetic. The validated number is forwarded as a parameter rather than re-derived, which is strictly cleaner than before. Two targeted regression tests cover both the fix and the new error path. No pre-existing behaviour is altered for valid numeric ports.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/port-binding.ts | Adds `resolveRequestedPort` to coerce and validate config port before arithmetic; passes the validated number through to `listenServerWithFallback`, eliminating both the string-concatenation bug and the previously noted redundant double-call. |
| src/test/listen.test.ts | Adds two regression tests: one verifying a string port binds the correct numeric port, and one verifying an invalid string port rejects with the expected error message. |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Caller
    participant listenServer
    participant resolveRequestedPort
    participant listenServerWithFallback
    participant buildCandidatePorts
    participant listenOnce

    Caller->>listenServer: listenServer(server, config, allowPortFallback)
    listenServer->>resolveRequestedPort: resolveRequestedPort(config)
    Note over resolveRequestedPort: Coerce config.port to number<br/>Validate 0 ≤ port ≤ 65535
    resolveRequestedPort-->>listenServer: requestedPort: number
    listenServer->>listenServerWithFallback: (server, config, requestedPort, allowPortFallback)
    listenServerWithFallback->>buildCandidatePorts: (requestedPort, allowPortFallback)
    buildCandidatePorts-->>listenServerWithFallback: candidatePorts[]
    loop for each candidatePort
        listenServerWithFallback->>listenOnce: (server, candidatePort, host)
        alt success
            listenOnce-->>listenServerWithFallback: resolved
        else EADDRINUSE
            listenOnce-->>listenServerWithFallback: rejected (try next)
        end
    end
    listenServerWithFallback-->>listenServer: boundPort
    listenServer->>listenServer: logServerStarted(config, requestedPort, boundPort)
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/port-binding.ts`, line 83-134 ([link](https://github.com/antelopejs/api/blob/be892598865d26231562d5c053b2278775468507/src/port-binding.ts#L83-L134)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Redundant double call to `resolveRequestedPort`**

   `listenServer` calls `resolveRequestedPort(config)` directly (line 134) to capture `requestedPort` for logging, then immediately passes the same `config` into `listenServerWithFallback`, which calls `resolveRequestedPort(config)` a second time. Because neither `config.port` nor `config.protocol` change between the two calls, both invocations return the same value. The cleaner fix is to accept `requestedPort` as a parameter in `listenServerWithFallback` instead of re-deriving it from config.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/port-binding.ts
   Line: 83-134

   Comment:
   **Redundant double call to `resolveRequestedPort`**

   `listenServer` calls `resolveRequestedPort(config)` directly (line 134) to capture `requestedPort` for logging, then immediately passes the same `config` into `listenServerWithFallback`, which calls `resolveRequestedPort(config)` a second time. Because neither `config.port` nor `config.protocol` change between the two calls, both invocations return the same value. The cleaner fix is to accept `requestedPort` as a parameter in `listenServerWithFallback` instead of re-deriving it from config.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["refactor(server): pass resolved port int..."](https://github.com/antelopejs/api/commit/0197b0c2eb84cb1140f52db69c41debaf3376367) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37688150)</sub>

<!-- /greptile_comment -->