### PR TITLE
chore(deps): bump antelope interface dependencies to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,8 +49,8 @@
     }
   },
   "dependencies": {
-    "@antelopejs/interface-api": "^0.0.4",
-    "@antelopejs/interface-api-util": "^0.0.2",
+    "@antelopejs/interface-api": "^0.0.5",
+    "@antelopejs/interface-api-util": "^0.1.1",
     "@antelopejs/interface-core": "^0.0.5",
     "reflect-metadata": "^0.2.2",
     "ws": "^8.20.0"

--- a/playground/package.json
+++ b/playground/package.json
@@ -6,9 +6,9 @@
     "dev": "ajs project run -w"
   },
   "dependencies": {
-    "@antelopejs/interface-api": "^0.0.2",
-    "@antelopejs/interface-api-util": "^0.0.2",
-    "@antelopejs/interface-core": "^0.0.2"
+    "@antelopejs/interface-api": "^0.0.5",
+    "@antelopejs/interface-api-util": "^0.1.1",
+    "@antelopejs/interface-core": "^0.0.5"
   },
   "devDependencies": {
     "@types/node": "^20.5.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,11 +9,11 @@ importers:
   .:
     dependencies:
       '@antelopejs/interface-api':
-        specifier: ^0.0.4
-        version: 0.0.4
+        specifier: ^0.0.5
+        version: 0.0.5(@antelopejs/interface-core@0.0.5)
       '@antelopejs/interface-api-util':
-        specifier: ^0.0.2
-        version: 0.0.2
+        specifier: ^0.1.1
+        version: 0.1.1(@antelopejs/interface-api@0.0.5(@antelopejs/interface-core@0.0.5))(@antelopejs/interface-core@0.0.5)
       '@antelopejs/interface-core':
         specifier: ^0.0.5
         version: 0.0.5
@@ -58,14 +58,14 @@ importers:
   playground:
     dependencies:
       '@antelopejs/interface-api':
-        specifier: ^0.0.2
-        version: 0.0.2
+        specifier: ^0.0.5
+        version: 0.0.5(@antelopejs/interface-core@0.0.5)
       '@antelopejs/interface-api-util':
-        specifier: ^0.0.2
-        version: 0.0.2
+        specifier: ^0.1.1
+        version: 0.1.1(@antelopejs/interface-api@0.0.5(@antelopejs/interface-core@0.0.5))(@antelopejs/interface-core@0.0.5)
       '@antelopejs/interface-core':
-        specifier: ^0.0.2
-        version: 0.0.2
+        specifier: ^0.0.5
+        version: 0.0.5
     devDependencies:
       '@types/node':
         specifier: ^20.5.7
@@ -79,20 +79,16 @@ importers:
 
 packages:
 
-  '@antelopejs/interface-api-util@0.0.2':
-    resolution: {integrity: sha512-ifBdZnmRL/5LqZQpG8F3KREQ0o5CVCJR5oOUnj8FLqruitmXujdcdRN1GcyjTQXG7urFhauE9TwFI4WXN3OGdQ==}
+  '@antelopejs/interface-api-util@0.1.1':
+    resolution: {integrity: sha512-8q1diSFuq5CULr9T/Dzo3DAOKmoN3zu84w3PgV2aGRPT3nMujcOxHyR+DEv9iA1ZxirUx5oskBmWVCaXtHNLVQ==}
+    peerDependencies:
+      '@antelopejs/interface-api': '>=0.0.3 <1.0.0'
+      '@antelopejs/interface-core': '>=0.0.3 <1.0.0'
 
-  '@antelopejs/interface-api@0.0.2':
-    resolution: {integrity: sha512-wD9kODuc5cns8mCVv4hLL3N8eF2iXtXoMgtDS7zJ3hZZoPnlpxZ7mDP4fMRUDBl0pm9ZTPKb5abzu3BZg6T/EA==}
-
-  '@antelopejs/interface-api@0.0.4':
-    resolution: {integrity: sha512-vrDLOQPt3LMHc8UUVzUVIuI3tJvkX8iFqdDsuUpW6vxlW4KwMS46k5O6/TlnqHjb9U9A1lSRkCLFhf98oCEMDQ==}
-
-  '@antelopejs/interface-core@0.0.2':
-    resolution: {integrity: sha512-CmtOJvSCRj20GOQhrE0PpHybGaW1G1lrepiKHVJa/bclhrvFYgHV0MH84TMpMOHESQT/+wuup007tfXAwaI+Eg==}
-
-  '@antelopejs/interface-core@0.0.3':
-    resolution: {integrity: sha512-Kw3ffGiQHKJ88AqdFfPuwzl+v0w6QqzqiqnLY7M0MYYw+YwdRNXh5WAJkep0ePudR9leLGXPU//FYizNaDG6yw==}
+  '@antelopejs/interface-api@0.0.5':
+    resolution: {integrity: sha512-BApviHE1vVkORDWtC8x8N2xCxBdFZZnhgMlxDuUmlXz2fGlYqBX1inIQQrEyOY31Zc/WN7nJpcA0zjjwk7Sp9A==}
+    peerDependencies:
+      '@antelopejs/interface-core': '>=0.0.3 <1.0.0'
 
   '@antelopejs/interface-core@0.0.5':
     resolution: {integrity: sha512-4H6hpFfiK2+DE8vL2mEtPbq1WNch9lt40QNr9KjBrOAtnuq/zMfIlzhbEsda39m+FVkMWXfUYoVolRogVKCLIQ==}
@@ -1230,26 +1226,14 @@ packages:
 
 snapshots:
 
-  '@antelopejs/interface-api-util@0.0.2':
+  '@antelopejs/interface-api-util@0.1.1(@antelopejs/interface-api@0.0.5(@antelopejs/interface-core@0.0.5))(@antelopejs/interface-core@0.0.5)':
     dependencies:
-      '@antelopejs/interface-api': 0.0.2
-      '@antelopejs/interface-core': 0.0.2
+      '@antelopejs/interface-api': 0.0.5(@antelopejs/interface-core@0.0.5)
+      '@antelopejs/interface-core': 0.0.5
 
-  '@antelopejs/interface-api@0.0.2':
+  '@antelopejs/interface-api@0.0.5(@antelopejs/interface-core@0.0.5)':
     dependencies:
-      '@antelopejs/interface-core': 0.0.2
-
-  '@antelopejs/interface-api@0.0.4':
-    dependencies:
-      '@antelopejs/interface-core': 0.0.3
-
-  '@antelopejs/interface-core@0.0.2':
-    dependencies:
-      reflect-metadata: 0.2.2
-
-  '@antelopejs/interface-core@0.0.3':
-    dependencies:
-      reflect-metadata: 0.2.2
+      '@antelopejs/interface-core': 0.0.5
 
   '@antelopejs/interface-core@0.0.5':
     dependencies:


### PR DESCRIPTION
Bump `@antelopejs/interface-*` dependencies (and playground) to the latest published versions. Interfaces stay in `dependencies` (the core resolves a module's interfaces from its package.json dependencies). Verified: install (single interface-core), build, lint.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Bumps the `@antelopejs/interface-*` family of packages to their latest published versions across the root package and the playground, and regenerates the `pnpm-lock.yaml` accordingly.

- `@antelopejs/interface-api` is moved from `^0.0.4` to `^0.0.5`; `@antelopejs/interface-api-util` makes a larger jump from `^0.0.2` to `^0.1.1`, and both packages now declare `@antelopejs/interface-core` (and `interface-api` for the util) as peer dependencies instead of regular dependencies — which is correctly satisfied by having them in the root `dependencies`.
- The playground is brought in sync with the same versions, and the lock file is regenerated cleanly with all old resolution entries removed.

<h3>Confidence Score: 5/5</h3>

Straightforward dependency bump with no logic changes; all peer dependency ranges are satisfied by packages already declared in root dependencies.

All three changed files are manifest/lock updates only. The structural shift from bundled dependencies to peer dependencies in interface-api-util@0.1.1 is handled correctly — the peer packages are present in the root dependencies and are resolved properly in the lock file. No source code was modified.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| package.json | Bumps @antelopejs/interface-api (0.0.4→0.0.5) and @antelopejs/interface-api-util (0.0.2→0.1.1); interface-core stays at 0.0.5. |
| playground/package.json | Aligns all three interface dependencies in the playground to the same versions as the root package (0.0.5, 0.1.1, 0.0.5). |
| pnpm-lock.yaml | Lock file regenerated cleanly; old versions removed, new resolutions show interface-api and interface-core correctly wired as peer dependencies for interface-api-util@0.1.1. |

</details>

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    Root["package.json (root)"]
    Playground["playground/package.json"]

    subgraph "Updated Dependencies"
        API["@antelopejs/interface-api\n0.0.4 → 0.0.5"]
        UTIL["@antelopejs/interface-api-util\n0.0.2 → 0.1.1"]
        CORE["@antelopejs/interface-core\n0.0.5 (unchanged)"]
    end

    Root --> API
    Root --> UTIL
    Root --> CORE

    Playground --> API
    Playground --> UTIL
    Playground --> CORE

    API -->|peerDep ≥0.0.3 <1.0.0| CORE
    UTIL -->|peerDep ≥0.0.3 <1.0.0| API
    UTIL -->|peerDep ≥0.0.3 <1.0.0| CORE
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    Root["package.json (root)"]
    Playground["playground/package.json"]

    subgraph "Updated Dependencies"
        API["@antelopejs/interface-api\n0.0.4 → 0.0.5"]
        UTIL["@antelopejs/interface-api-util\n0.0.2 → 0.1.1"]
        CORE["@antelopejs/interface-core\n0.0.5 (unchanged)"]
    end

    Root --> API
    Root --> UTIL
    Root --> CORE

    Playground --> API
    Playground --> UTIL
    Playground --> CORE

    API -->|peerDep ≥0.0.3 <1.0.0| CORE
    UTIL -->|peerDep ≥0.0.3 <1.0.0| API
    UTIL -->|peerDep ≥0.0.3 <1.0.0| CORE
```

</a>

<sub>Reviews (1): Last reviewed commit: ["chore(deps): bump antelope interface dep..."](https://github.com/antelopejs/api/commit/6e1febb12ac21f1754ed600a2d6cffef4c748cb8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37903959)</sub>

<!-- /greptile_comment -->