### PR TITLE
chore(deps): use floating semver ranges for antelope modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     }
   },
   "dependencies": {
-    "@antelopejs/interface-api": "^0.0.7",
+    "@antelopejs/interface-api": "^0.0.8",
     "@antelopejs/interface-api-util": "^0.1.1",
     "@antelopejs/interface-core": "^0.0.6",
     "reflect-metadata": "^0.2.2",

--- a/playground/package.json
+++ b/playground/package.json
@@ -6,7 +6,7 @@
     "dev": "ajs project run -w"
   },
   "dependencies": {
-    "@antelopejs/interface-api": "^0.0.7",
+    "@antelopejs/interface-api": "^0.0.8",
     "@antelopejs/interface-api-util": "^0.1.1",
     "@antelopejs/interface-core": "^0.0.6"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,11 +9,11 @@ importers:
   .:
     dependencies:
       '@antelopejs/interface-api':
-        specifier: ^0.0.7
-        version: 0.0.7(@antelopejs/interface-core@0.0.6)
+        specifier: ^0.0.8
+        version: 0.0.8(@antelopejs/interface-core@0.0.6)
       '@antelopejs/interface-api-util':
         specifier: ^0.1.1
-        version: 0.1.1(@antelopejs/interface-api@0.0.7(@antelopejs/interface-core@0.0.6))(@antelopejs/interface-core@0.0.6)
+        version: 0.1.1(@antelopejs/interface-api@0.0.8(@antelopejs/interface-core@0.0.6))(@antelopejs/interface-core@0.0.6)
       '@antelopejs/interface-core':
         specifier: ^0.0.6
         version: 0.0.6
@@ -58,11 +58,11 @@ importers:
   playground:
     dependencies:
       '@antelopejs/interface-api':
-        specifier: ^0.0.7
-        version: 0.0.7(@antelopejs/interface-core@0.0.6)
+        specifier: ^0.0.8
+        version: 0.0.8(@antelopejs/interface-core@0.0.6)
       '@antelopejs/interface-api-util':
         specifier: ^0.1.1
-        version: 0.1.1(@antelopejs/interface-api@0.0.7(@antelopejs/interface-core@0.0.6))(@antelopejs/interface-core@0.0.6)
+        version: 0.1.1(@antelopejs/interface-api@0.0.8(@antelopejs/interface-core@0.0.6))(@antelopejs/interface-core@0.0.6)
       '@antelopejs/interface-core':
         specifier: ^0.0.6
         version: 0.0.6
@@ -85,8 +85,8 @@ packages:
       '@antelopejs/interface-api': '>=0.0.3 <1.0.0'
       '@antelopejs/interface-core': '>=0.0.3 <1.0.0'
 
-  '@antelopejs/interface-api@0.0.7':
-    resolution: {integrity: sha512-RaepQjtHJsXMvr5+bNT8UA/BnZJn63PsdXWl010QeImONdf9vczlXX55oCh/kjo5lS2RdCa33YaF/gvTqo2Ikg==}
+  '@antelopejs/interface-api@0.0.8':
+    resolution: {integrity: sha512-LWXPsbvkCG2AblP6r0+h4K0v3jxSpAoE/1SG5pkTPspaSa+H3aYvBiRwKphmISw0/4YU801OG5dfxeV5gNu/jA==}
     peerDependencies:
       '@antelopejs/interface-core': '>=0.0.3 <1.0.0'
 
@@ -1226,12 +1226,12 @@ packages:
 
 snapshots:
 
-  '@antelopejs/interface-api-util@0.1.1(@antelopejs/interface-api@0.0.7(@antelopejs/interface-core@0.0.6))(@antelopejs/interface-core@0.0.6)':
+  '@antelopejs/interface-api-util@0.1.1(@antelopejs/interface-api@0.0.8(@antelopejs/interface-core@0.0.6))(@antelopejs/interface-core@0.0.6)':
     dependencies:
-      '@antelopejs/interface-api': 0.0.7(@antelopejs/interface-core@0.0.6)
+      '@antelopejs/interface-api': 0.0.8(@antelopejs/interface-core@0.0.6)
       '@antelopejs/interface-core': 0.0.6
 
-  '@antelopejs/interface-api@0.0.7(@antelopejs/interface-core@0.0.6)':
+  '@antelopejs/interface-api@0.0.8(@antelopejs/interface-core@0.0.6)':
     dependencies:
       '@antelopejs/interface-core': 0.0.6
 


### PR DESCRIPTION
## What

Bump the `@antelopejs/*` interface dependencies to their latest published versions and refresh the pnpm lockfile:

- `@antelopejs/interface-api`: `^0.0.7` -> `^0.0.8` (root and `playground`)

`@antelopejs/interface-api-util` (`^0.1.1`) and `@antelopejs/interface-core` (`^0.0.6`) are already at their latest published versions. The `playground/antelope.config.ts` only references `type: "local"` modules, so no config version pins needed changing.

## Why

Part of the multi-repo campaign to keep antelope module references on floating semver ranges (`^x.y.z`). Now that `@antelopejs/core` 1.4.5 supports floating ranges in `antelope.config`, keeping these dependencies on caret ranges pointing at the latest published versions means antelope module versions stay current automatically.

## Verification

- `pnpm install` (lockfile updated)
- `pnpm build` (tsc, clean)
- `pnpm lint` (biome, only a pre-existing warning)
- `pnpm test` (106 passing)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR bumps `@antelopejs/interface-api` from `^0.0.7` to `^0.0.8` in both the root and `playground` packages, regenerating the pnpm lockfile to match. The change is part of a campaign to keep antelope module references on floating caret ranges pointing at the latest published versions.

- `package.json` and `playground/package.json`: specifier updated from `^0.0.7` → `^0.0.8` for `@antelopejs/interface-api`.
- `pnpm-lock.yaml`: resolved version updated to `0.0.8` with a new integrity hash; the `@antelopejs/interface-api-util@0.1.1` peer dependency snapshot is updated consistently to reference the new resolved version.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a minimal, mechanical version bump with a correctly regenerated lockfile.

Both manifest files and the lockfile are updated consistently: the specifier moves from ^0.0.7 to ^0.0.8, the resolved version in the lockfile follows, the integrity hash is replaced, and the @antelopejs/interface-api-util peer snapshot is updated to reference the new resolved version. No application code, configuration, or other dependencies are touched.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| package.json | Bumps @antelopejs/interface-api specifier from ^0.0.7 to ^0.0.8; no other changes. |
| playground/package.json | Mirrors root package.json: bumps @antelopejs/interface-api specifier from ^0.0.7 to ^0.0.8 for consistency. |
| pnpm-lock.yaml | Lockfile regenerated to resolve @antelopejs/interface-api to 0.0.8 with updated integrity hash; @antelopejs/interface-api-util snapshot peer updated accordingly; all other entries unchanged. |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["package.json - interface-api 0.0.7 to 0.0.8"] --> C["pnpm-lock.yaml - resolved 0.0.8 with new integrity hash"]
    B["playground/package.json - interface-api 0.0.7 to 0.0.8"] --> C
    C --> D["interface-api-util@0.1.1 peer snapshot updated to 0.0.8"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["package.json - interface-api 0.0.7 to 0.0.8"] --> C["pnpm-lock.yaml - resolved 0.0.8 with new integrity hash"]
    B["playground/package.json - interface-api 0.0.7 to 0.0.8"] --> C
    C --> D["interface-api-util@0.1.1 peer snapshot updated to 0.0.8"]
```

</a>

<sub>Reviews (1): Last reviewed commit: ["chore(deps): bump antelope interface dep..."](https://github.com/antelopejs/api/commit/85d497604b751eeb9884151f273afeb2ac651413) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44401667)</sub>

<!-- /greptile_comment -->