### PR TITLE
feat(cors): reflect loopback origins in development mode

### DIFF
--- a/src/dev-mode.ts
+++ b/src/dev-mode.ts
@@ -1,0 +1,36 @@
+import { Logging } from "@antelopejs/interface-core/logging";
+import { GetRuntimeInfo } from "@antelopejs/interface-core/runtime";
+
+const DEFAULT_DEV_MODE = false;
+
+let devMode = DEFAULT_DEV_MODE;
+
+/**
+ * Tells whether the module runs under a development runtime.
+ *
+ * The value is cached so that synchronous handlers can read it.
+ */
+export function isDevMode(): boolean {
+  return devMode;
+}
+
+/**
+ * Overrides the cached development runtime flag.
+ */
+export function setDevMode(enabled: boolean): void {
+  devMode = enabled;
+}
+
+/**
+ * Reads the runtime information once and caches its development flag.
+ */
+export async function resolveDevMode(): Promise<void> {
+  try {
+    const runtimeInfo = await GetRuntimeInfo();
+    setDevMode(runtimeInfo.dev);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    Logging.Warn(`Unable to resolve the development runtime flag: ${message}`);
+    setDevMode(DEFAULT_DEV_MODE);
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import type { CorsConfig } from "@antelopejs/interface-api";
 import { ImplementInterface } from "@antelopejs/interface-core";
 import { Logging } from "@antelopejs/interface-core/logging";
 import type { DevServerEndpoint } from "@antelopejs/interface-core/runtime";
+import { resolveDevMode } from "./dev-mode";
 import {
   collectListeningEndpoints,
   registerDevServerEndpoints,
@@ -37,6 +38,7 @@ export function setCorsConfig(cors: CorsConfig): void {
 
 export async function construct(config: Config): Promise<void> {
   configure(config);
+  await resolveDevMode();
 
   void ImplementInterface(
     await import("@antelopejs/interface-api"),

--- a/src/middlewares/cors.ts
+++ b/src/middlewares/cors.ts
@@ -9,6 +9,7 @@ import {
   type RequestContext,
 } from "@antelopejs/interface-api";
 import { getConfig } from "..";
+import { isDevMode } from "../dev-mode";
 
 type RequestHeaderValue = string | string[] | undefined;
 
@@ -17,6 +18,9 @@ const FALSE_ORIGIN = "false";
 const CREDENTIALS_ENABLED_VALUE = "true";
 const NO_BODY_LENGTH = "0";
 const DEFAULT_CREDENTIALS = true;
+const LOOPBACK_PROTOCOLS = ["http:", "https:"];
+const LOOPBACK_HOSTNAMES = ["localhost", "127.0.0.1", "::1", "[::1]"];
+const DEV_FALLBACK_CORS_CONFIG: CorsConfig = {};
 
 function isString(value: unknown): value is string {
   return typeof value === "string" || value instanceof String;
@@ -47,6 +51,39 @@ function isOriginAllowed(
   }
 
   return Boolean(allowedOrigin);
+}
+
+function isLoopbackOrigin(origin: string): boolean {
+  try {
+    const url = new URL(origin);
+    if (url.origin !== origin) {
+      return false;
+    }
+
+    return (
+      LOOPBACK_PROTOCOLS.includes(url.protocol) &&
+      LOOPBACK_HOSTNAMES.includes(url.hostname)
+    );
+  } catch {
+    return false;
+  }
+}
+
+function isRequestOriginAllowed(origin: string, cors: CorsConfig): boolean {
+  if (isOriginAllowed(origin, cors.allowedOrigins)) {
+    return true;
+  }
+
+  return isDevMode() && isLoopbackOrigin(origin);
+}
+
+function resolveCorsConfig(): CorsConfig | undefined {
+  const cors = getConfig().cors;
+  if (cors) {
+    return cors;
+  }
+
+  return isDevMode() ? DEV_FALLBACK_CORS_CONFIG : undefined;
 }
 
 function isCredentialsEnabled(cors: CorsConfig): boolean {
@@ -124,7 +161,7 @@ function addStandardCorsHeaders(
 export class Cors extends Controller("") {
   @Prefix("any", "/", HandlerPriority.HIGHEST)
   cors(@Context() requestContext: RequestContext): HTTPResult | undefined {
-    const cors = getConfig().cors;
+    const cors = resolveCorsConfig();
 
     if (!cors) {
       return undefined;
@@ -132,7 +169,7 @@ export class Cors extends Controller("") {
 
     const requestOrigin = requestContext.rawRequest.headers.origin;
     const isAllowed = requestOrigin
-      ? isOriginAllowed(requestOrigin, cors.allowedOrigins)
+      ? isRequestOriginAllowed(requestOrigin, cors)
       : false;
     const allowedOriginHeader =
       isAllowed && requestOrigin ? requestOrigin : FALSE_ORIGIN;

--- a/src/middlewares/cors.ts
+++ b/src/middlewares/cors.ts
@@ -21,6 +21,8 @@ const DEFAULT_CREDENTIALS = true;
 const LOOPBACK_PROTOCOLS = ["http:", "https:"];
 const LOOPBACK_HOSTNAMES = ["localhost", "127.0.0.1", "::1", "[::1]"];
 const DEV_FALLBACK_CORS_CONFIG: CorsConfig = {};
+const PREFLIGHT_METHOD = "OPTIONS";
+const PREFLIGHT_REQUEST_METHOD_HEADER = "access-control-request-method";
 
 function isString(value: unknown): value is string {
   return typeof value === "string" || value instanceof String;
@@ -67,6 +69,14 @@ function isLoopbackOrigin(origin: string): boolean {
   } catch {
     return false;
   }
+}
+
+function isPreflightRequest(requestContext: RequestContext): boolean {
+  return (
+    requestContext.rawRequest.method === PREFLIGHT_METHOD &&
+    requestContext.rawRequest.headers[PREFLIGHT_REQUEST_METHOD_HEADER] !==
+      undefined
+  );
 }
 
 function isRequestOriginAllowed(origin: string, cors: CorsConfig): boolean {
@@ -174,7 +184,7 @@ export class Cors extends Controller("") {
     const allowedOriginHeader =
       isAllowed && requestOrigin ? requestOrigin : FALSE_ORIGIN;
 
-    if (requestContext.rawRequest.method === "OPTIONS") {
+    if (isPreflightRequest(requestContext)) {
       const response = new HTTPResult(204, null);
       addPreflightHeaders(response, requestContext, allowedOriginHeader, cors);
       return response;

--- a/src/test/cors.test.ts
+++ b/src/test/cors.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert";
 import { HTTPResult, type RequestContext } from "@antelopejs/interface-api";
+import { isDevMode, setDevMode } from "../dev-mode";
 import { GetCorsConfig, SetCorsConfig } from "../implementations/api";
 import { configure, getConfig, setCorsConfig } from "../index";
 import { Cors } from "../middlewares/cors";
@@ -8,6 +9,20 @@ const ALLOWED_ORIGIN = "https://example.com";
 const DISALLOWED_ORIGIN = "https://evil.com";
 const REQUESTED_HEADERS = "x-custom";
 const PREFLIGHT_STATUS = 204;
+const LOOPBACK_ORIGIN = "http://localhost:3000";
+const LOOPBACK_IPV4_ORIGIN = "http://127.0.0.1:5173";
+const LOOPBACK_IPV6_ORIGIN = "http://[::1]:4000";
+const LOOPBACK_HTTPS_ORIGIN = "https://localhost:8443";
+const LOOKALIKE_ORIGINS = [
+  "http://localhost.evil.com:3000",
+  "https://evil.com/?u=http://localhost:3000",
+  "ftp://localhost:3000",
+  "http://localhost:3000/",
+  "http://localhost@evil.com",
+  "localhost:3000",
+  "not an origin",
+  "",
+];
 
 interface RequestHeaders {
   origin?: string;
@@ -29,15 +44,26 @@ function preflightHeaders(headers: RequestHeaders): Record<string, string> {
   return result.getHeaders();
 }
 
+function standardHeaders(headers: RequestHeaders): Record<string, string> {
+  const context = buildContext("GET", headers);
+  const result = corsController.cors(context);
+  assert.equal(result, undefined);
+  return context.response.getHeaders();
+}
+
 describe("CORS", () => {
   let originalConfig: ReturnType<typeof getConfig>;
+  let originalDevMode: boolean;
 
   before(() => {
     originalConfig = getConfig();
+    originalDevMode = isDevMode();
+    setDevMode(false);
   });
 
   after(() => {
     configure(originalConfig);
+    setDevMode(originalDevMode);
   });
 
   it("round-trips the configuration through the contract functions", () => {
@@ -156,5 +182,112 @@ describe("CORS", () => {
     const headers = preflightHeaders({ origin: ALLOWED_ORIGIN });
 
     assert.equal(headers["Access-Control-Max-Age"], undefined);
+  });
+});
+
+describe("CORS loopback origins", () => {
+  let originalConfig: ReturnType<typeof getConfig>;
+  let originalDevMode: boolean;
+
+  before(() => {
+    originalConfig = getConfig();
+    originalDevMode = isDevMode();
+  });
+
+  after(() => {
+    configure(originalConfig);
+    setDevMode(originalDevMode);
+  });
+
+  beforeEach(() => {
+    configure({ servers: [] });
+    setDevMode(true);
+  });
+
+  it("reflects a loopback origin without any CORS configuration", () => {
+    const headers = standardHeaders({ origin: LOOPBACK_ORIGIN });
+
+    assert.equal(headers["Access-Control-Allow-Origin"], LOOPBACK_ORIGIN);
+    assert.equal(headers["Access-Control-Allow-Credentials"], "true");
+    assert.equal(headers.Vary, "Origin");
+  });
+
+  it("reflects a loopback origin on preflight without any CORS configuration", () => {
+    const headers = preflightHeaders({
+      origin: LOOPBACK_ORIGIN,
+      "access-control-request-headers": REQUESTED_HEADERS,
+    });
+
+    assert.equal(headers["Access-Control-Allow-Origin"], LOOPBACK_ORIGIN);
+    assert.equal(headers["Access-Control-Allow-Credentials"], "true");
+    assert.equal(headers["Access-Control-Allow-Headers"], REQUESTED_HEADERS);
+  });
+
+  it("reflects every loopback host form", () => {
+    const loopbackOrigins = [
+      LOOPBACK_ORIGIN,
+      LOOPBACK_IPV4_ORIGIN,
+      LOOPBACK_IPV6_ORIGIN,
+      LOOPBACK_HTTPS_ORIGIN,
+    ];
+
+    for (const origin of loopbackOrigins) {
+      const headers = standardHeaders({ origin });
+      assert.equal(headers["Access-Control-Allow-Origin"], origin);
+    }
+  });
+
+  it("reflects a loopback origin alongside an unrelated allow list", () => {
+    setCorsConfig({ allowedOrigins: ALLOWED_ORIGIN });
+
+    const headers = standardHeaders({ origin: LOOPBACK_ORIGIN });
+
+    assert.equal(headers["Access-Control-Allow-Origin"], LOOPBACK_ORIGIN);
+  });
+
+  it("keeps honouring the configured origins", () => {
+    setCorsConfig({ allowedOrigins: ALLOWED_ORIGIN });
+
+    const headers = standardHeaders({ origin: ALLOWED_ORIGIN });
+
+    assert.equal(headers["Access-Control-Allow-Origin"], ALLOWED_ORIGIN);
+  });
+
+  it("rejects an unlisted non-loopback origin", () => {
+    setCorsConfig({ allowedOrigins: ALLOWED_ORIGIN });
+
+    const headers = standardHeaders({ origin: DISALLOWED_ORIGIN });
+
+    assert.equal(headers["Access-Control-Allow-Origin"], "false");
+  });
+
+  it("rejects origins that only look like loopback ones", () => {
+    for (const origin of LOOKALIKE_ORIGINS) {
+      const headers = standardHeaders({ origin });
+      assert.equal(
+        headers["Access-Control-Allow-Origin"],
+        "false",
+        `expected ${origin} to be rejected`,
+      );
+    }
+  });
+
+  it("skips handling outside of dev mode when no configuration is set", () => {
+    setDevMode(false);
+
+    const context = buildContext("GET", { origin: LOOPBACK_ORIGIN });
+    const result = corsController.cors(context);
+
+    assert.equal(result, undefined);
+    assert.deepEqual(context.response.getHeaders(), {});
+  });
+
+  it("does not reflect a loopback origin outside of dev mode", () => {
+    setDevMode(false);
+    setCorsConfig({ allowedOrigins: ALLOWED_ORIGIN });
+
+    const headers = standardHeaders({ origin: LOOPBACK_ORIGIN });
+
+    assert.equal(headers["Access-Control-Allow-Origin"], "false");
   });
 });

--- a/src/test/cors.test.ts
+++ b/src/test/cors.test.ts
@@ -27,7 +27,10 @@ const LOOKALIKE_ORIGINS = [
 interface RequestHeaders {
   origin?: string;
   "access-control-request-headers"?: string;
+  "access-control-request-method"?: string;
 }
+
+const PREFLIGHT_REQUESTED_METHOD = "GET";
 
 const corsController = new Cors();
 
@@ -39,7 +42,11 @@ function buildContext(method: string, headers: RequestHeaders): RequestContext {
 }
 
 function preflightHeaders(headers: RequestHeaders): Record<string, string> {
-  const result = corsController.cors(buildContext("OPTIONS", headers));
+  const preflight: RequestHeaders = {
+    "access-control-request-method": PREFLIGHT_REQUESTED_METHOD,
+    ...headers,
+  };
+  const result = corsController.cors(buildContext("OPTIONS", preflight));
   assert.ok(result instanceof HTTPResult);
   return result.getHeaders();
 }
@@ -139,7 +146,10 @@ describe("CORS", () => {
     });
 
     const result = corsController.cors(
-      buildContext("OPTIONS", { origin: ALLOWED_ORIGIN }),
+      buildContext("OPTIONS", {
+        origin: ALLOWED_ORIGIN,
+        "access-control-request-method": PREFLIGHT_REQUESTED_METHOD,
+      }),
     );
 
     assert.ok(result instanceof HTTPResult);
@@ -259,6 +269,33 @@ describe("CORS loopback origins", () => {
     const headers = standardHeaders({ origin: DISALLOWED_ORIGIN });
 
     assert.equal(headers["Access-Control-Allow-Origin"], "false");
+  });
+
+  it("lets an ordinary OPTIONS request reach routing", () => {
+    const context = buildContext("OPTIONS", { origin: LOOPBACK_ORIGIN });
+
+    const result = corsController.cors(context);
+
+    assert.equal(result, undefined);
+    assert.equal(
+      context.response.getHeaders()["Access-Control-Allow-Origin"],
+      LOOPBACK_ORIGIN,
+    );
+  });
+
+  it("lets an ordinary OPTIONS request through with a configured allow list", () => {
+    setDevMode(false);
+    setCorsConfig({ allowedOrigins: ALLOWED_ORIGIN });
+
+    const context = buildContext("OPTIONS", { origin: ALLOWED_ORIGIN });
+
+    const result = corsController.cors(context);
+
+    assert.equal(result, undefined);
+    assert.equal(
+      context.response.getHeaders()["Access-Control-Allow-Origin"],
+      ALLOWED_ORIGIN,
+    );
   });
 
   it("rejects origins that only look like loopback ones", () => {


### PR DESCRIPTION
## Problem

Dev setups currently have to hardcode an `allowedOrigins` list in every project config, enumerating every port the dev frontend may fall back to:

```ts
cors: {
  allowedOrigins: [
    "http://localhost:3000", "http://localhost:3001", /* ... */
  ],
},
```

because the middleware is a complete no-op when the `cors` block is absent, and rejects any origin not in the allowlist. Origins registered at runtime through `SetCorsConfig` are also wiped by the next `configure()`, so the static list keeps coming back.

## Change

- Cache the runtime `dev` flag once during `construct()` (new `src/dev-mode.ts`) — the `@Prefix` handler is synchronous, `GetRuntimeInfo()` is not. Resolution failure logs a warning and fails closed to `false`.
- In dev mode, treat loopback origins as allowed: `http:`/`https:` on `localhost`, `127.0.0.1` or `[::1]`, any port. The origin is parsed with `new URL` and compared against `url.origin`, so `http://localhost.evil.com`, userinfo tricks, bare `host:port` strings and malformed values stay rejected.
- The reflected value is always the exact request origin with `Vary: Origin` — never `*`, since credentials default to enabled.
- In dev mode the middleware also runs without a `cors` config block (empty-config fallback), covering projects that have no CORS config at all.
- The loopback check is additive: configured origins keep working exactly as before.

## Production behavior — unchanged

Outside dev: an absent `cors` block still disables the middleware entirely, and only origins matching `allowedOrigins` are allowed. Loopback origins get no special treatment.

## Tests

9 new tests (`CORS loopback origins` suite): reflection with and without config on standard + preflight paths, all loopback host forms incl. bracketed IPv6, allowlist still honored, non-loopback rejection, a lookalike-origin battery, and dev-off behavior. The existing suite now pins dev mode off. 109 passing, lint clean.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR enables credentialed CORS reflection for exact HTTP(S) loopback origins in development mode while preserving configured origins and production behavior.
- Caches the runtime development flag during module construction, failing closed when runtime resolution fails.
- Adds strict loopback-origin parsing and a development-only empty CORS configuration fallback.
- Restricts synthetic preflight responses to OPTIONS requests carrying `Access-Control-Request-Method`, allowing ordinary OPTIONS routes to execute.
- Adds coverage for loopback variants, lookalike rejection, preflight behavior, configured allowlists, and disabled development mode.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/dev-mode.ts | Adds asynchronous runtime development-mode resolution with a synchronous cached accessor and fail-closed fallback. |
| src/index.ts | Resolves and caches development mode during construction before interface registration. |
| src/middlewares/cors.ts | Adds development-only loopback-origin reflection and correctly limits preflight interception to OPTIONS requests carrying the preflight method header. |
| src/test/cors.test.ts | Expands CORS tests and confirms the previously reported ordinary OPTIONS interception is fixed. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(cors): only intercept OPTIONS reques..."](https://github.com/antelopejs/api/commit/f903eadd31ad440ce28595dca74b8fbc2c9fe8d4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51157417)</sub>

<!-- /greptile_comment -->