### PR TITLE
docs(readme): document dev loopback origin reflection in CORS section

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ The API module automatically adds a middleware for CORS support, which can be co
 - `allowedOrigins`: An array of allowed origins or regular expressions
 - `allowedMethods`: An array of allowed HTTP methods
 
+In development (when the runtime reports `dev`), loopback origins — `localhost`, `127.0.0.1` and `[::1]`, on any port — are accepted automatically, with or without a `cors` block, so local frontends need no configuration. The request origin is reflected as-is, never `*`. In production, and for non-loopback development frontends (e.g. a LAN address), origins must be listed explicitly in `allowedOrigins`.
+
 ## License
 
 This project is licensed under the Apache License 2.0 - see the [LICENSE](LICENSE) file for details.


### PR DESCRIPTION
Follow-up to #26: the CORS Configuration section of the README did not mention the development behavior shipped in 1.2.0. Add a paragraph documenting the automatic loopback origin reflection in dev (with or without a `cors` block, reflected origin, never `*`) and the cases that still require an explicit `allowedOrigins` list (production, non-loopback dev frontends).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds README documentation describing automatic loopback-origin reflection for CORS in development.
- Clarifies that `localhost`, `127.0.0.1`, and `[::1]` are accepted on any port.
- Explains that the request origin is reflected rather than using `*`.
- Notes that production and non-loopback development origins still require explicit `allowedOrigins` configuration.

<h3>Confidence Score: 5/5</h3>

The documentation-only change appears safe to merge.

The added paragraph clearly describes the intended development loopback behavior and distinguishes production and non-loopback configuration requirements, with no accepted defects or rule violations.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| README.md | Documents development loopback CORS behavior and the cases requiring explicit origin configuration; no actionable issue was identified. |

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(readme): document dev loopback orig..."](https://github.com/antelopejs/api/commit/25c83adf7f70004b0ce329baa1bd72cf62387f3c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51444039)</sub>

<!-- /greptile_comment -->