### PR TITLE
chore(deps): let the interface range reach UnregisterRoute

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     }
   },
   "dependencies": {
-    "@antelopejs/interface-api": "^0.0.8",
+    "@antelopejs/interface-api": ">=0.0.10 <1.0.0",
     "@antelopejs/interface-api-util": "^0.1.1",
     "@antelopejs/interface-core": "^0.0.6",
     "reflect-metadata": "^0.2.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,11 +9,11 @@ importers:
   .:
     dependencies:
       '@antelopejs/interface-api':
-        specifier: ^0.0.8
-        version: 0.0.8(@antelopejs/interface-core@0.0.6)
+        specifier: '>=0.0.10 <1.0.0'
+        version: 0.0.10(@antelopejs/interface-core@0.0.6)
       '@antelopejs/interface-api-util':
         specifier: ^0.1.1
-        version: 0.1.1(@antelopejs/interface-api@0.0.8(@antelopejs/interface-core@0.0.6))(@antelopejs/interface-core@0.0.6)
+        version: 0.1.1(@antelopejs/interface-api@0.0.10(@antelopejs/interface-core@0.0.6))(@antelopejs/interface-core@0.0.6)
       '@antelopejs/interface-core':
         specifier: ^0.0.6
         version: 0.0.6
@@ -83,6 +83,11 @@ packages:
     resolution: {integrity: sha512-8q1diSFuq5CULr9T/Dzo3DAOKmoN3zu84w3PgV2aGRPT3nMujcOxHyR+DEv9iA1ZxirUx5oskBmWVCaXtHNLVQ==}
     peerDependencies:
       '@antelopejs/interface-api': '>=0.0.3 <1.0.0'
+      '@antelopejs/interface-core': '>=0.0.3 <1.0.0'
+
+  '@antelopejs/interface-api@0.0.10':
+    resolution: {integrity: sha512-nToojyDDp/175hR3ryuxFxlU9zyKcSr2/V+ftEySlpVHO469skNkG9s9U8OPmFMH9wj/t2iul9gNB6/NvNo7KQ==}
+    peerDependencies:
       '@antelopejs/interface-core': '>=0.0.3 <1.0.0'
 
   '@antelopejs/interface-api@0.0.8':
@@ -1226,9 +1231,18 @@ packages:
 
 snapshots:
 
+  '@antelopejs/interface-api-util@0.1.1(@antelopejs/interface-api@0.0.10(@antelopejs/interface-core@0.0.6))(@antelopejs/interface-core@0.0.6)':
+    dependencies:
+      '@antelopejs/interface-api': 0.0.10(@antelopejs/interface-core@0.0.6)
+      '@antelopejs/interface-core': 0.0.6
+
   '@antelopejs/interface-api-util@0.1.1(@antelopejs/interface-api@0.0.8(@antelopejs/interface-core@0.0.6))(@antelopejs/interface-core@0.0.6)':
     dependencies:
       '@antelopejs/interface-api': 0.0.8(@antelopejs/interface-core@0.0.6)
+      '@antelopejs/interface-core': 0.0.6
+
+  '@antelopejs/interface-api@0.0.10(@antelopejs/interface-core@0.0.6)':
+    dependencies:
       '@antelopejs/interface-core': 0.0.6
 
   '@antelopejs/interface-api@0.0.8(@antelopejs/interface-core@0.0.6)':


### PR DESCRIPTION
The interface dependency read `^0.0.8` — and an npm caret on a `0.0.x` version pins **that exact patch** (`>=0.0.8 <0.0.9`). Nothing depending on this module could ever resolve interface-api 0.0.10, where `UnregisterRoute` (AntelopeJS/interface-api#13) ships.

This matters beyond this package: the AntelopeJS loader hands every module of a deployment the **implementor's** interface copy. The pin here therefore decided the interface version for every consumer — the CMS page teardown calls `UnregisterRoute` and got `TypeError: not a function` in any environment where this module supplies the interface.

Widened to `>=0.0.10 <1.0.0`, the range shape consumers already use for 0.x interfaces. Lockfile resolves 0.0.10; 120 tests passing.

Consumer waiting on this: the CMS `fix/release-page-route` branch, which releases a page's own layout route on unregistration — the last registry its teardown did not reclaim.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Updates `@antelopejs/interface-api` so consumers can resolve the `UnregisterRoute` API introduced in version 0.0.10.

- Widens the dependency range from `^0.0.8` to `>=0.0.10 <1.0.0`.
- Updates the lockfile’s root resolution and utility peer snapshot to interface-api 0.0.10.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the manifest and lockfile consistently enabling interface-api 0.0.10.

The dependency range now reaches the required interface release, and the lockfile consistently resolves the root package and interface utility against version 0.0.10 without an identified current failure.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| package.json | Widens the interface-api dependency range to include version 0.0.10 and subsequent compatible pre-1.0 releases. |
| pnpm-lock.yaml | Consistently updates the root importer and dependency snapshots to interface-api 0.0.10 while retaining the separately required 0.0.8 snapshot. |

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(deps): let the interface range rea..."](https://github.com/antelopejs/api/commit/56d4bb623586bf536ac600f6dfffdf04175da742) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51831448)</sub>

<!-- /greptile_comment -->